### PR TITLE
Rc/v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+# [v0.25.1](https://github.com/cryptape/cita-sdk-swift/compare/v0.24.1...v0.25.1) (2019-08-22)
+
+* Update to support CITA v0.25.1.
+
 # [v0.24.1](https://github.com/cryptape/cita-sdk-swift/compare/v0.24...v0.24.1) (2019-05-31)
 
 ### FIX

--- a/CITA.podspec
+++ b/CITA.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CITA"
-  s.version      = "0.24.1"
+  s.version      = "0.25.1"
   s.summary      = "CITA SDK implementation in Swift for iOS"
 
   s.description  = <<-DESC

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.24.1</string>
+	<string>0.25.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
It doesn't seem to need to be changed. [CITA v0.25.0 CHANGELOG](https://github.com/cryptape/cita/releases/tag/v0.25.0)
I connected my temporarily running CITA v0.25.1 node http://129.226.69.73:1337 and verified all the tests.